### PR TITLE
Add React/Vite frontend with Firebase login

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Marianna Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "firebase": "^9.6.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^3.1.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,22 @@
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import LoginButton from './components/LoginButton';
+import Dashboard from './components/Dashboard';
+import ProtectedRoute from './components/ProtectedRoute';
+
+export default function App() {
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={<LoginButton />} />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+      </Routes>
+    </Router>
+  );
+}

--- a/frontend/src/api/firebase.js
+++ b/frontend/src/api/firebase.js
@@ -1,0 +1,15 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth, GoogleAuthProvider, signInWithPopup, signOut } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: "AIza....",
+  authDomain: "your-app.firebaseapp.com",
+  projectId: "your-app-id",
+  appId: "1:1234567890:web:abcd"
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const provider = new GoogleAuthProvider();
+
+export { auth, signInWithPopup, signOut, provider };

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,0 +1,3 @@
+export default function Dashboard() {
+  return <div>Dashboard: You're logged in!</div>;
+}

--- a/frontend/src/components/LoginButton.jsx
+++ b/frontend/src/components/LoginButton.jsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { auth, provider, signInWithPopup, signOut } from '../api/firebase';
+import { useNavigate } from 'react-router-dom';
+
+export default function LoginButton() {
+  const [user, setUser] = useState(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged((u) => {
+      setUser(u);
+      if (u) navigate('/dashboard');
+    });
+    return () => unsubscribe();
+  }, [navigate]);
+
+  const handleLogin = async () => {
+    try {
+      const result = await signInWithPopup(auth, provider);
+      setUser(result.user);
+      navigate('/dashboard');
+    } catch (err) {
+      console.error('Login error', err);
+    }
+  };
+
+  const handleLogout = () => {
+    signOut(auth);
+  };
+
+  return user ? (
+    <div>
+      <p>👋 Welcome, {user.displayName}</p>
+      <button onClick={handleLogout}>Logout</button>
+    </div>
+  ) : (
+    <button onClick={handleLogin}>Login with Google</button>
+  );
+}

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { auth } from '../api/firebase';
+import { Navigate } from 'react-router-dom';
+
+export default function ProtectedRoute({ children }) {
+  const [user, setUser] = useState(undefined);
+
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged((u) => setUser(u));
+    return () => unsubscribe();
+  }, []);
+
+  if (user === undefined) return null;
+  if (!user) return <Navigate to="/" />;
+  return children;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- scaffold React/Vite project in `frontend/`
- include Firebase auth setup
- add login button and protected route components

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68765ca26ae483258668798cef7f4038